### PR TITLE
standalone _python2.sh first line updated

### DIFF
--- a/sl4atools/standalone_python2.sh
+++ b/sl4atools/standalone_python2.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /system/bin/sh
 st=`for i in /mnt/storage /mnt/sdcard /sdcard; do [ -d $i ] && echo $i && break; done`
 if [ x$api != x ]; then :
 elif ! type \cut > /dev/null; then api=14; else


### PR DESCRIPTION
standalone_python2.sh updated to run Python easily on Terminal:
As Android executes commands after searching from /system/bin directory and  not from /bin directory ,the first line of standalone_python2.sh has to be  changed from #! /bin/sh to as shown below:
#! /system/bin/sh
After this is done and this new edited file is  copied to /system/bin directory,then Python can be easily run on Terminal app with this command:
standalone_python2.sh 
you can rename this script to whatever you desire and use that name as command.
If you use previous version of standalone _python2.sh  file  and try to use command: standalone _python2.sh to run Python, you will get error as :No such file
Earlier,you had to run Python on Terminal with command like this:
sh /system/bin/standalone _python2.sh
This command is longer  and there are chances of mistake in typing.
By using updated version,you can easily run Python now.